### PR TITLE
Update link in warning hint text

### DIFF
--- a/lib/api/src/modules/stories.ts
+++ b/lib/api/src/modules/stories.ts
@@ -85,7 +85,7 @@ const deprecatedOptionsParameterWarnings: Record<string, () => void> = [
   acc[option] = deprecate(
     () => {},
     `parameters.options.${option} is deprecated and will be removed in Storybook 7.0.
-To change this setting, use \`addons.setConfig\`. See https://github.com/storybookjs/storybook/MIGRATION.md#deprecated-immutable-options-parameters
+To change this setting, use \`addons.setConfig\`. See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-immutable-options-parameters
   `
   );
   return acc;


### PR DESCRIPTION
The original link led to a page not found. I have found what I think is the correct link and updated.

## Issue
To reproduce:
- Cause a warning in the console about using `parameters.options.theme`
- The text of the warning should read 
```
parameters.options.theme is deprecated and will be removed in Storybook 7.0.
To change this setting, use `addons.setConfig`. See https://github.com/storybookjs/storybook/MIGRATION.md#deprecated-immutable-options-parameters
```
- Click the link specified in the warning message
- The link should lead to a "Not found" page

## What I did
I updated the link in the warning text to a currently working link.

## How to test
I don't believe that the validity of links in warning text is testable by Jest, Chromatic, etc.
To manually test, cause a warning about using `parameters.options.theme`, and click the link the warning. The link should now go to a valid page. 
